### PR TITLE
tokenizer.tokenize 按当前最新结果修改

### DIFF
--- a/_c2/2021-12-11-transformers-note-2.md
+++ b/_c2/2021-12-11-transformers-note-2.md
@@ -153,10 +153,11 @@ print(tokens)
 ```
 
 ```
-['using', 'a', 'transform', '##er', 'network', 'is', 'simple']
+['Using', 'a', 'Trans', '##former', 'network', 'is', 'simple']
 ```
 
-可以看到，BERT 分词器采用的是子词切分策略，它会不断切分词语直到获得词表中的 token，例如 “transformer” 会被切分为 “transform” 和 “##er”。
+可以看到，BERT 分词器采用的是子词切分策略，它会不断切分词语直到获得词表中的 token，例如 “Transformer” 会被切分为 “Trans” 和 “##former”。
+（旧版本有少许差别： [revision ae1d3b](https://huggingface.co/google-bert/bert-base-cased/commit/ae1d3b2cce5ef798cab884c0e7e61e34f46bc412) 之前的结果是：`['using', 'a', 'transform', '##er', 'network', 'is', 'simple']`）
 
 然后，我们通过 `convert_tokens_to_ids()` 将切分出的 tokens 转换为对应的 token IDs：
 


### PR DESCRIPTION
结果和描述之前是不对，但是修改称旧版的了。现在按最新版本纠正结果和描述。

测试代码：
``` python
from transformers import AutoTokenizer


def test_tokenizer(revision):
    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", revision=revision)
    sequence = "Using a Transformer network is simple"
    tokens = tokenizer.tokenize(sequence)
    print(f"revision: {revision}")
    print(tokens)


test_tokenizer("main")
test_tokenizer("b89a729bdafaf5e18b8cb1774aee7fbc363169f1")
test_tokenizer("ae1d3b2cce5ef798cab884c0e7e61e34f46bc412")
```
代码结果：
```
revision: main
['Using', 'a', 'Trans', '##former', 'network', 'is', 'simple']
revision: b89a729bdafaf5e18b8cb1774aee7fbc363169f1
['Using', 'a', 'Trans', '##former', 'network', 'is', 'simple']
revision: ae1d3b2cce5ef798cab884c0e7e61e34f46bc412
['using', 'a', 'transform', '##er', 'network', 'is', 'simple']
```